### PR TITLE
Remove G+ and planet links, fix some contact info

### DIFF
--- a/history.html
+++ b/history.html
@@ -165,7 +165,7 @@ href="http://lists.nothinbut.net/mail/listinfo/plug">PLUG mailing list</a>.
 <p>
 When did meetings change to the 1st Wednesday of every month ?
 <br>If you have any further information, or mailing list archives from before  January 1999,
-please email it to <a href="mailto:lyz@princessleia.com">Elizabeth Krumbach</a>.
+please email it to <a href="mailo:waltman@pobox.com">Walt Mankowski</a>.
 
 
 <p>A history of meeting subject, speakers, and count of attendees can be found

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   </ul>
 <li><b><a href="talks.html">Previous Meeting Info</a></b>
   <ul>
-    <li><b><a href="https://photos.google.com/share/AF1QipMhsGRv2FpSlM5DHq73loBWCeuwJXSDQ7fo2nzZzUyUyir4ELuEFZmgCrN745G4MQ?key=U0FFNHhRbFlndUNzYjRNUjRyZmFHYk1MUGNZSjdR">Videos of some recent talks</a></b> and more are available on <a href="https://plus.google.com/communities/113596509667444287356">our Google+ Page</a>
+    <li><b><a href="https://photos.google.com/share/AF1QipMhsGRv2FpSlM5DHq73loBWCeuwJXSDQ7fo2nzZzUyUyir4ELuEFZmgCrN745G4MQ?key=U0FFNHhRbFlndUNzYjRNUjRyZmFHYk1MUGNZSjdR">Videos of some recent talks</a></b></li>
   </ul>
 <p>
 
@@ -65,7 +65,6 @@
 <li>Follow <b>@phillylinux</b> on <b><a href="http://twitter.com/phillylinux">Twitter</a></b> for updates
 <li>Chat with us on <b><a href="irc.html">IRC</a></b>
 <li>PLUG Amateur Radio: We now have a Fusion room (YSF37358) and unnamed DMR talkgroup (TG3141922)
-<li>Read posts from <b><a href="http://planet.phillylinux.org">PLUG members' blogs</a></b>
 <p>
 
 <li><b><a href="/keys/">Philadelphia Linux GPG Keysigning Parties</a></b>

--- a/logo.html
+++ b/logo.html
@@ -24,6 +24,6 @@ Download Other Versions of Logo (.svg .png .jpg / color, b&amp;w)
 
 <p>PLUG has been granted the rights to use the images however it sees fit. Others can use the Franklin Tux images via a <a href="http://creativecommons.org/licenses/by-nc/3.0/">Creative Commons BY-NC</a> license (by Stephanie Fox for PLUG/phillylinux.org, based on Larry Ewing's Tux). The NC restriction is waived if proceeds from the commercial use of the image are given to PLUG.</p>
 
-<p>Please send comments, questions and licensing inquiries to <a href="mailto:lyz@princessleia.com">Elizabeth Krumbach</a></p>
+<p>Please send comments, questions and licensing inquiries to <a href="mailto:lyz@princessleia.com">Elizabeth K. Joseph</a></p>
 </body>
 </html>


### PR DESCRIPTION
Remove the now defunct G+ and planet links, also update the history
page with Lyz's contact info to Walt's, and update Lyz's name on
the logo page (she is still the one to contact there).